### PR TITLE
Upgrade to PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,8 @@
     }
   },
   "require": {
-    "php": "^7.2",
-    "guzzlehttp/guzzle": "~6.0",
-    "guzzlehttp/psr7": "^1.4",
-    "league/omnipay": "~3.0"
+    "php": "^8.0",
+    "league/omnipay": "^3.2.1"
   },
   "scripts": {
     "test": "phpunit"


### PR DESCRIPTION
Dropped guzzle dependency, as it is not required anymore (league/omnipay loads its own guzzle)